### PR TITLE
Add openSeaChest headers to the ndm build base image

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -90,30 +90,3 @@ jobs:
             DBUILD_SITE_URL=https://openebs.io
             RELEASE_TAG=${{ env.RELEASE_TAG }}
 
-  trivy:
-    runs-on: ubuntu-latest
-    needs: ['ndm-build-base']
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-
-      - name: Set Image Org 
-        # sets the default IMAGE_ORG to openebs
-        run: |
-          [ -z "${{ secrets.IMAGE_ORG }}" ] && IMAGE_ORG=openebs || IMAGE_ORG=${{ secrets.IMAGE_ORG}}
-          echo "IMAGE_ORG=${IMAGE_ORG}" >> $GITHUB_ENV
-        
-      - name: Set Release Tag
-        run: |
-          TAG="${GITHUB_REF#refs/*/v}"
-          echo "RELEASE_TAG=${TAG}" >> $GITHUB_ENV
-        
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: ghcr.io/${{ env.IMAGE_ORG }}/ndm-build-base:${{ env.RELEASE_TAG }}
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'
-

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -50,22 +50,3 @@ jobs:
           platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
           tags: |
             openebs/ndm-build-base:ci
-
-      - name: Load image to docker
-        uses: docker/build-push-action@v2
-        with:
-          file: ./build/ndm-build-base/Dockerfile
-          push: false
-          load: true
-          platforms: linux/amd64
-          tags: |
-            openebs/ndm-build-base:ci
-
-      - name: Run Trivy vulnerability scanner
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: 'openebs/ndm-build-base:ci'
-          format: 'table'
-          exit-code: '1'
-          ignore-unfixed: true
-          severity: 'CRITICAL,HIGH'

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -46,11 +46,21 @@ jobs:
         with:
           file: ./build/ndm-build-base/Dockerfile
           push: false
-          load: true
+          load: false
           platforms: linux/amd64, linux/arm64, linux/arm/v7, linux/ppc64le
           tags: |
             openebs/ndm-build-base:ci
-        
+
+      - name: Load image to docker
+        uses: docker/build-push-action@v2
+        with:
+          file: ./build/ndm-build-base/Dockerfile
+          push: false
+          load: true
+          platforms: linux/amd64
+          tags: |
+            openebs/ndm-build-base:ci
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:

--- a/build/ndm-build-base/Dockerfile
+++ b/build/ndm-build-base/Dockerfile
@@ -7,11 +7,17 @@ RUN make release
 WORKDIR /tmp/openSeachest
 RUN cp opensea-common/Make/gcc/lib/libopensea-common.a /usr/lib && \
     cp opensea-operations/Make/gcc/lib/libopensea-operations.a /usr/lib && \
-    cp opensea-transport/Make/gcc/lib/libopensea-transport.a /usr/lib
+    cp opensea-transport/Make/gcc/lib/libopensea-transport.a /usr/lib && \
+    # Copy include headers
+    cp -r include /usr/local/include/openSeaChest && \
+    cp -r opensea-common/include /usr/local/include/openSeaChest/opensea-common && \
+    cp -r opensea-operations/include /usr/local/include/openSeaChest/opensea-operations && \
+    cp -r opensea-transport/include /usr/local/include/openSeaChest/opensea-transport
 
 FROM golang:1.14.7
-RUN apt-get update && apt-get install -y libudev-dev libblkid-dev
+RUN apt-get update && apt-get install -y make git libudev-dev libblkid-dev
 COPY --from=build /usr/lib/libopensea-* /usr/lib/
+COPY --from=build /usr/local/include /usr/local/include/
 WORKDIR /go/src/github.com/openebs/node-disk-manager/
 ARG DBUILD_DATE
 ARG DBUILD_REPO_URL="https://github.com/openebs/openSeaChest"


### PR DESCRIPTION
ndm requires openSeaChest include headers to build. Add the headers to
the build base image.

Tested locally. Image builds. Also, successfully built ndm image using this new image after adding a few `CFLAGS`.

Signed-off-by: Aditya Jain <aditya.jainadityajain.jain@gmail.com>
